### PR TITLE
"Fixed" the Win 8 editor size issue by resizing in visual studio - VS/.NET bug by the looks of it...

### DIFF
--- a/FluentSharp.REPL/Ascx/ascx_SourceCodeViewer.Designer.cs
+++ b/FluentSharp.REPL/Ascx/ascx_SourceCodeViewer.Designer.cs
@@ -28,28 +28,31 @@ namespace FluentSharp.REPL.Controls
         /// </summary>
         private void InitializeComponent()
         {
-            this.sourceCodeEditor = new SourceCodeEditor();
+            this.sourceCodeEditor = new FluentSharp.REPL.Controls.SourceCodeEditor();
             this.SuspendLayout();
             // 
             // sourceCodeEditor
             // 
+            this.sourceCodeEditor._ShowSearchAndAstDetails = true;
             this.sourceCodeEditor._ShowTopMenu = false;
             this.sourceCodeEditor.AllowDrop = true;
             this.sourceCodeEditor.BackColor = System.Drawing.SystemColors.Control;
             this.sourceCodeEditor.Dock = System.Windows.Forms.DockStyle.Fill;
             this.sourceCodeEditor.ForeColor = System.Drawing.Color.Black;
             this.sourceCodeEditor.Location = new System.Drawing.Point(0, 0);
+            this.sourceCodeEditor.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.sourceCodeEditor.Name = "sourceCodeEditor";
-            this.sourceCodeEditor.Size = new System.Drawing.Size(517, 318);
+            this.sourceCodeEditor.Size = new System.Drawing.Size(1276, 516);
             this.sourceCodeEditor.TabIndex = 0;
             // 
             // ascx_SourceCodeViewer
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.sourceCodeEditor);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "ascx_SourceCodeViewer";
-            this.Size = new System.Drawing.Size(517, 318);
+            this.Size = new System.Drawing.Size(1276, 516);
             this.ResumeLayout(false);
 
         }

--- a/FluentSharp.REPL/FluentSharp.REPL.csproj
+++ b/FluentSharp.REPL/FluentSharp.REPL.csproj
@@ -254,6 +254,9 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="H2Logo.ico" />
+    <EmbeddedResource Include="Ascx\ascx_SourceCodeViewer.resx">
+      <DependentUpon>ascx_SourceCodeViewer.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="_Embedded_Dlls\WeifenLuo.WinFormsUI.Docking.dll" />
     <EmbeddedResource Include="_O2_External_WinFormsUI\Forms\GenericDockContent.resx">
       <DependentUpon>GenericDockContent.cs</DependentUpon>


### PR DESCRIPTION
"Fixed" the win 8 editor size by resizing in visual studio, then debugging - it now correctly display in VS and on the actual program when running.
I'm calling it a VS / .NET bug

All changes to the files are auto generated by VS, after a resize, followed by a debug.
Reverted and tested before and after to prove to myself the difference was real.
