### PR TITLE
Fixing appveyor build https://github.com/o2platform/FluentSharp/issues/57

### DIFF
--- a/FluentSharp.CoreLib/O2_DotNetWrappers/Windows/Win32_Window.cs
+++ b/FluentSharp.CoreLib/O2_DotNetWrappers/Windows/Win32_Window.cs
@@ -71,7 +71,7 @@ namespace FluentSharp.CoreLib.API
         public static IntPtr win32_Desktop_Window_With_Title(this string title, bool waitForWindow = true)
         {
             var wait_Count = 10;
-            var wait_Value = 100;
+            var wait_Value = 1000;
             var window = Win32_Window.FindWindowsWithText(title).first();    
             if (window != default(IntPtr))
                 return window;

--- a/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
+++ b/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
@@ -59,7 +59,7 @@ namespace UnitTests.FluentSharp.CoreLib
         public void parentFolder_Open_in_Explorer()
         {
             var tmpDir = "_open_In_explorer".tempDir();
-            var envs = Environment.GetEnvironmentVariables();
+            var envs = Environment.GetEnvironmentVariables().toList();
             foreach (var item in envs)
             {
                 Console.WriteLine(item);

--- a/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
+++ b/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
@@ -64,7 +64,9 @@ namespace UnitTests.FluentSharp.CoreLib
             var envs = Environment.GetEnvironmentVariables().toList<DictionaryEntry>();
             foreach (var item in envs)
             {
+                Console.WriteLine(item.Key);
                 Console.WriteLine(item.Value);
+                Console.WriteLine("---");
             }
             tmpDir.parentFolder_Open_in_Explorer().assert_Is_Not_Null();
             var windowTitle = tmpDir.parent_Folder().folderName();

--- a/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
+++ b/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
@@ -59,6 +59,11 @@ namespace UnitTests.FluentSharp.CoreLib
         public void parentFolder_Open_in_Explorer()
         {
             var tmpDir = "_open_In_explorer".tempDir();
+            var envs = Environment.GetEnvironmentVariables();
+            foreach (var item in envs)
+            {
+                Console.WriteLine(item);
+            }
             tmpDir.parentFolder_Open_in_Explorer().assert_Is_Not_Null();
             var windowTitle = tmpDir.parent_Folder().folderName();
             windowTitle.error();

--- a/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
+++ b/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
@@ -61,15 +61,15 @@ namespace UnitTests.FluentSharp.CoreLib
         public void parentFolder_Open_in_Explorer()
         {
             var tmpDir = "_open_In_explorer".tempDir();
-            var envs = Environment.GetEnvironmentVariables().toList<DictionaryEntry>();
-            foreach (var item in envs)
-            {
-                if (item.Value.ToString().contains("appveyor"))
-                { 
-                    "Appveyor is running in terminal mode.(Skipping)".assert_Ignore();
-                    return;
-                }
-            }
+            //var envs = Environment.GetEnvironmentVariables().toList<DictionaryEntry>();
+            //foreach (var item in envs)
+            //{
+            //    if (item.Value.ToString().contains("appveyor"))
+            //    { 
+            //        "Appveyor is running in terminal mode.(Skipping)".assert_Ignore();
+            //        return;
+            //    }
+            //}
             tmpDir.parentFolder_Open_in_Explorer().assert_Is_Not_Null();
             var windowTitle = tmpDir.parent_Folder().folderName();
             windowTitle.error();

--- a/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
+++ b/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
@@ -64,9 +64,11 @@ namespace UnitTests.FluentSharp.CoreLib
             var envs = Environment.GetEnvironmentVariables().toList<DictionaryEntry>();
             foreach (var item in envs)
             {
-                Console.WriteLine(item.Key);
-                Console.WriteLine(item.Value);
-                Console.WriteLine("---");
+                if (item.Value.ToString().contains("appveyor"))
+                { 
+                    "Appveyor is running in terminal mode.(Skipping)".assert_Ignore();
+                    return;
+                }
             }
             tmpDir.parentFolder_Open_in_Explorer().assert_Is_Not_Null();
             var windowTitle = tmpDir.parent_Folder().folderName();

--- a/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
+++ b/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
@@ -3,6 +3,8 @@ using FluentSharp.CoreLib.API;
 using FluentSharp.NUnit;
 using NUnit.Framework;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Security.AccessControl;
@@ -59,10 +61,10 @@ namespace UnitTests.FluentSharp.CoreLib
         public void parentFolder_Open_in_Explorer()
         {
             var tmpDir = "_open_In_explorer".tempDir();
-            var envs = Environment.GetEnvironmentVariables().toList();
+            var envs = Environment.GetEnvironmentVariables().toList<DictionaryEntry>();
             foreach (var item in envs)
             {
-                Console.WriteLine(item);
+                Console.WriteLine(item.Value);
             }
             tmpDir.parentFolder_Open_in_Explorer().assert_Is_Not_Null();
             var windowTitle = tmpDir.parent_Folder().folderName();

--- a/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
+++ b/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
@@ -74,7 +74,7 @@ namespace UnitTests.FluentSharp.CoreLib
             var windowTitle = tmpDir.parent_Folder().folderName();
             windowTitle.error();
             var window = windowTitle.win32_Desktop_Window_With_Title();            
-            window.assert_Not_Default()
+            window
                   .win32_CloseWindow().assert_True();
             
             "".parentFolder_Open_in_Explorer().assert_Is_Null();

--- a/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
+++ b/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
@@ -74,7 +74,7 @@ namespace UnitTests.FluentSharp.CoreLib
             var windowTitle = tmpDir.parent_Folder().folderName();
             windowTitle.error();
             var window = windowTitle.win32_Desktop_Window_With_Title();            
-            window
+            window.assert_Not_Default()
                   .win32_CloseWindow().assert_True();
             
             "".parentFolder_Open_in_Explorer().assert_Is_Null();

--- a/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
+++ b/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
@@ -61,15 +61,6 @@ namespace UnitTests.FluentSharp.CoreLib
         public void parentFolder_Open_in_Explorer()
         {
             var tmpDir = "_open_In_explorer".tempDir();
-            //var envs = Environment.GetEnvironmentVariables().toList<DictionaryEntry>();
-            //foreach (var item in envs)
-            //{
-            //    if (item.Value.ToString().contains("appveyor"))
-            //    { 
-            //        "Appveyor is running in terminal mode.(Skipping)".assert_Ignore();
-            //        return;
-            //    }
-            //}
             tmpDir.parentFolder_Open_in_Explorer().assert_Is_Not_Null();
             var windowTitle = tmpDir.parent_Folder().folderName();
             windowTitle.error();

--- a/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
+++ b/UnitTests/UnitTests.FluentSharp.CoreLib/ExtensionMethods/IO/Test_IO_ExtensionMethods_Folders.cs
@@ -3,8 +3,6 @@ using FluentSharp.CoreLib.API;
 using FluentSharp.NUnit;
 using NUnit.Framework;
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Security.AccessControl;


### PR DESCRIPTION
In order to launch UI test in appveyor you need to set Operating System : "Unstable" in environment settings.
![image](https://cloud.githubusercontent.com/assets/1903628/6086798/45a0ffec-ae4d-11e4-955c-a6abeee028d8.png)

Also , I have to increase wainting time because  windows explorer is launching slower on Appveyor.
